### PR TITLE
Add Price Per Token to General AI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 
 ## General AI
 
+- [Price Per Token](https://pricepertoken.com/) - Compare LLM API pricing across 300+ models from OpenAI, Anthropic, Google, and 30+ providers.
 - [TensorFlow](https://www.tensorflow.org/) - An open-source platform for machine learning, providing a comprehensive ecosystem of tools.
 - [PyTorch](https://pytorch.org/) - An open-source deep learning framework that provides a flexible and dynamic computation graph.
 - [Scikit-learn](https://scikit-learn.org/stable/) - A Python library for machine learning, featuring various classification, regression, and clustering algorithms.


### PR DESCRIPTION
## Add Price Per Token

[Price Per Token](https://pricepertoken.com) is a free tool for comparing LLM API pricing across 300+ models from 30+ providers including OpenAI, Anthropic, Google, and more.

### Features:
- Compare pricing for 300+ LLM models
- Token counter supporting all major tokenizers
- Pricing calculator for cost estimation
- Free to use, no signup required

Added to the General AI section.